### PR TITLE
Fix shinylive version of app

### DIFF
--- a/app/app.R
+++ b/app/app.R
@@ -54,8 +54,12 @@ server <- function(input, output, session) {
   db$URL <- paste0("https://CRAN.R-project.org/package=", db$Package)
   db$Deadline <- as.Date(db$Deadline)
   db$Days <- db$Deadline - Sys.Date()
-  db <- db |> sort_by(~list(Deadline, Package))
-
+  if (is_emscripten()) {
+    db <- db[order(db$Deadline, db$Package),]
+  } else {
+    db <- db |> sort_by(~list(Deadline, Package))
+  }
+  
   cards_list <- vector("list", length = nrow(db))
 
   for (i in seq(nrow(db))) {


### PR DESCRIPTION
This PR addresses #1 by updating the application code to compile and execute successfully with [`{shinylive}`](https://posit-dev.github.io/r-shinylive/):

* Add custom function `is_emscripten()` to detect if the R process is running in a web-assembly process. Full credit goes to [Winston Chang](https://github.com/wch) - source [shinylive/45 (comment)](https://github.com/posit-dev/r-shinylive/issues/45#issuecomment-1885233647)
* Add custom function `get_cran_db()` to provide two methods of downloading the CRAN package database:
     + When running in a traditional R process: use `tools::CRAN_package_db()`
     + When running in a web assembly process: Download the data set RDS file `packages.rds` directly from a CRAN mirror using a customized version of the URL that accounts for a web browser's downloading policies. Full credit goes to GH user [alekrutkowski](https://github.com/alekrutkowski) - source [webr/252 (comment)](https://github.com/r-wasm/webr/issues/252#issuecomment-1690142510)
* Add a condition to use a more traditional sorting method via `order()` for the data set if running inside a web-assembly process, due to R version 4.3.3 being the current version supported by webR. Once webR is updated to use R version 4.4.0 or later, this could be reverted to using the `sort_by()` function exclusively.

**IMPORTANT**: The development version of `{shinylive}` must be used to compile the application due to a recent bug fix in PR [shinylive/72](https://github.com/posit-dev/r-shinylive/pull/72).

I did not add the re-compiled assets in this PR in case you want to handle that on your end for a revised deployment.
